### PR TITLE
Predictable results in nanoid generation when given non-integer values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "barba-con-bigote",
             "version": "0.1.0",
             "dependencies": {
+                "nanoid": "^3.3.8",
                 "next": "14.2.21",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
@@ -985,15 +986,16 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -2625,9 +2627,9 @@
             }
         },
         "nanoid": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="
         },
         "next": {
             "version": "14.2.21",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "start": "next start"
     },
     "dependencies": {
+        "nanoid": "^3.3.8",
         "next": "14.2.21",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",


### PR DESCRIPTION
When nanoid is called with a fractional value, there were a number of undesirable effects:

in browser and non-secure, the code infinite loops on while (size--)
in node, the value of poolOffset becomes fractional, causing calls to nanoid to return zeroes until the pool is next filled
if the first call in node is a fractional argument, the initial buffer allocation fails with an error
Version 3.3.8 and 5.0.9 are fixed.