### PR TITLE
Fix LinkedIn URL and add Dribbble link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Juan D. Bolanos
+# Juan D. Bolaños
 
 **Sr. Product Designer** · Chalfont, PA
 
-[Portfolio](https://barbaconbigote.com) · [LinkedIn](https://linkedin.com/in/juandbolanos)
+[Portfolio](https://barbaconbigote.com) · [LinkedIn](https://www.linkedin.com/in/bolanosjd/) · [Dribbble](https://dribbble.com/WeebleWobb)
 
 ---
 


### PR DESCRIPTION
## Summary
Corrects the LinkedIn profile URL and adds Dribbble portfolio link to the README header.

## Problem
The LinkedIn URL was incorrect (pointed to a non-existent profile) and Dribbble was missing from social links.

## Solution
- Fixed LinkedIn URL to https://www.linkedin.com/in/bolanosjd/
- Added Dribbble link: https://dribbble.com/WeebleWobb

## Impact
Documentation-only change. No testing required.